### PR TITLE
Add a Quick start, pin agent deps, and give the reference run a landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@
 website** — same tasks, same real sites, scored on how often each method
 completes the task and what it costs in time, tokens, and dollars.
 
+## Quick start
+
+Just want the results? [Open the reference
+run.](results/2026-07-27-reference/)
+
+Run the harness for free (Node 20.11+, no key, no Docker):
+
+```bash
+npm ci
+WT_FAKE_LIFECYCLE=1 npm run bench    # no LLM — scores 0/7 by design, just proves it runs
+```
+
+Run the real benchmark — needs Docker, Linux, and a key
+([setup](#running-it-yourself)):
+
+```bash
+npx playwright install chromium
+export ANTHROPIC_API_KEY=sk-ant-...
+npm run bench -- --arms wm-claude,cu-claude --budget 2
+```
+
+Runs the 7 tasks on the three lightweight sites once each, same model on two
+interfaces — WebMCP against screenshots. 14 attempts, well under $1; `--budget`
+hard-stops the run if it isn't.
+
 ## Background: Three ways to operate a website
 
 A browser agent can operate a website through three main interfaces:
@@ -185,7 +210,7 @@ The three WebMCP methods were ~9% of that bill; full breakdown:
 
 ## Running it yourself
 
-**Setup.** You need Docker, Node 20+, and an API key for the model under test:
+**Setup.** You need Docker, Node 20.11+, and an API key for the model under test:
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,15 @@
   "packages": {
     "": {
       "name": "windtunnel",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.110.0",
+        "@anthropic-ai/sdk": "0.110.0",
         "@browserbasehq/stagehand": "3.6.0",
-        "js-yaml": "^4.1.0",
-        "playwright": "^1.54.1"
+        "js-yaml": "4.3.0",
+        "playwright": "1.61.1"
+      },
+      "engines": {
+        "node": ">=20.11"
       }
     },
     "node_modules/@ai-sdk/amazon-bedrock": {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "license": "Apache-2.0",
   "description": "A WebMCP benchmark — measures WebMCP against screenshot and DOM/a11y browser-agent interfaces on real self-hosted sites",
   "type": "module",
+  "engines": {
+    "node": ">=20.11"
+  },
   "scripts": {
     "bench": "node harness/cli.mjs",
     "test": "node --test"
   },
+  "// dependencies": "Pinned exact, not ranged: a silent minor bump in an agent SDK or in Chromium moves benchmark numbers, which would break comparability across runs the same way an unpinned site commit would. Bump deliberately, and note it in the run's PROVENANCE.md.",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.110.0",
+    "@anthropic-ai/sdk": "0.110.0",
     "@browserbasehq/stagehand": "3.6.0",
-    "js-yaml": "^4.1.0",
-    "playwright": "^1.54.1"
+    "js-yaml": "4.3.0",
+    "playwright": "1.61.1"
   }
 }

--- a/results/2026-07-27-reference/README.md
+++ b/results/2026-07-27-reference/README.md
@@ -1,0 +1,33 @@
+# Reference run — 2026-07-27
+
+7 methods × 49 tasks across 8 sites × 3 attempts = **1,029 attempts**, $102.68
+of model spend across the cells kept here. This is the run the top-level
+[README](../../README.md) reports; its ~$107 figure is the whole flight,
+including the attempts these re-runs superseded.
+
+| Interface | Method | Model | Solved | % |
+|---|---|---|---|---|
+| WebMCP | wm-claude | claude-sonnet-4-6 | 48/49 | 98% |
+| WebMCP | wm-gpt | gpt-5.5 | 47/49 | 96% |
+| WebMCP | wm-stagehand | claude-sonnet-4-6 | 47/49 | 96% |
+| Screenshots | cu-openai | gpt-5.5 | 44/49 | 90% |
+| DOM + vision | dom-browseruse | claude-sonnet-4-6 | 43/49 | 88% |
+| Page structure (a11y) | a11y-stagehand | claude-sonnet-4-6 | 42/49 | 86% |
+| Screenshots | cu-claude | claude-sonnet-4-6 | 39/49 | 80% |
+
+A task counts as **solved** when a majority of its 3 attempts pass. Scoring
+rules and pricing: [`docs/SPEC.md`](../../docs/SPEC.md).
+
+## What's in here
+
+| File | What it is |
+|---|---|
+| [`results.csv`](results.csv) | One row per attempt (1,029). GitHub renders it as a sortable table. |
+| `explorer.html` | Interactive explorer — filter by method, site, tier; read any transcript. **GitHub shows this as source code**; download it and open it in a browser. |
+| `explorer-artifact.html` | Same explorer, standalone build for embedding elsewhere. |
+| `run.json` | Everything, including full transcripts (10 MB). |
+| [`PROVENANCE.md`](PROVENANCE.md) | How this run was merged, and every post-run correction. |
+
+This is a merged reference — a base full run plus two targeted re-runs, with
+each cell attributed to its source. Read `PROVENANCE.md` before citing a
+number; it discloses the two oracle bugs that forced the re-runs.


### PR DESCRIPTION
Three independent changes, each verified against a clean clone on macOS.

### Quick start in the README
The first runnable command sat ~200 lines down, under a setup block requiring Docker, Playwright browsers, and a Python venv. The new section leads with the two things a visitor can do immediately.

The free path works on any platform — `WT_FAKE_LIFECYCLE=1` skips both the Linux-only capsule boot and the Chromium launch, so `npm ci` is the only prerequisite. It completes in under a second.

The paid path keeps `npx playwright install chromium` explicitly. **This is a real bug in the obvious shortcut:** `npm ci` does not fetch browsers (the installed `playwright` package has no install script), so without that line the first real run dies in `browserType.launch` with "Executable doesn't exist" before it ever boots a site.

### Pin agent deps exactly, declare the Node floor
The reproducibility argument covers the sites (pinned upstream commits) but not the harness's own agent stack. `@anthropic-ai/sdk`, `js-yaml`, and `playwright` were caret ranges; a clean clone today resolves playwright to **1.61.1**, seven minors past the declared `^1.54.1`. A silent SDK or Chromium bump moves benchmark numbers exactly the way an unpinned site commit would.

Also adds `engines: { node: ">=20.11" }`. The harness uses `import.meta.dirname` throughout `harness/` and `scoring/`, which landed in Node 20.11.0; on 20.0–20.10 it is `undefined` and the CLI dies inside `path.resolve` with an error naming neither the API nor the version. There was no `engines` field at all.

### Landing page for the reference run
Browsing `results/2026-07-27-reference/` showed a bare file list, and its one human-readable artifact renders as 219 KB of source on GitHub rather than as the explorer. GitHub renders a directory's `README.md` automatically, so the run backing every headline number now has a readable entry point: headline table, what each file is, and a note to download `explorer.html` rather than squint at the source view.

Its $102.68 is the spend across the cells kept in the merged run; the top-level README's ~$107 is the whole flight including superseded attempts. Worth a second pair of eyes on that reconciliation.

### Verification
- `npm ci` clean, lockfile unchanged afterward
- `npm test` — 40 passed, 0 failed
- `WT_FAKE_LIFECYCLE=1 npm run bench` — completes, writes a report, leaves the tree clean

Not verified: the paid command itself. Real site boots are Linux-only and this was checked on macOS, so its prerequisites and flag parsing are confirmed but it was never executed against a booted site. The "well under $1" estimate is arithmetic from the reference run's per-task medians (~$0.007 and ~$0.047 × 7 tasks ≈ $0.38), not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)