### PR TITLE
Add README badges and a CI workflow to back them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 20.11 is the declared floor (import.meta.dirname landed there);
+        # 22 is what most contributors actually run.
+        node: ['20.11', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test
+      # Dry run: no key, no Docker, no browser — exercises task loading,
+      # the arm loop, scoring, and report writing on every push.
+      - run: WT_FAKE_LIFECYCLE=1 npm run bench

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# WindTunnel — A WebMCP Benchmark
+<div align="center">
+
+# WindTunnel
+
+**A WebMCP benchmark.**
+
+[Quick start](#quick-start) · [Results](results/2026-07-27-reference/) · [Methodology](docs/SPEC.md) · [Cost](#cost) · [WebMCP spec](https://github.com/webmachinelearning/webmcp)
+
+[![license](https://img.shields.io/badge/license-Apache--2.0-a9c1a0?style=flat-square&labelColor=2f3336)](LICENSE)
+[![benchmark](https://img.shields.io/badge/benchmark-49%20tasks%20%C3%97%208%20sites-a9c1a0?style=flat-square&labelColor=2f3336)](tasks/)
+[![built on](https://img.shields.io/badge/built%20on-WebMCP-a9c1a0?style=flat-square&labelColor=2f3336)](https://github.com/webmachinelearning/webmcp)
+[![tests](https://img.shields.io/github/actions/workflow/status/nekuda-ai/WindTunnel/test.yml?branch=main&style=flat-square&label=tests&color=a9c1a0&labelColor=2f3336)](https://github.com/nekuda-ai/WindTunnel/actions/workflows/test.yml)
+[![results](https://img.shields.io/badge/results-reference%20run%20%C2%B7%201%2C029%20attempts-eaa47c?style=flat-square&labelColor=2f3336)](results/2026-07-27-reference/)
+
+</div>
 
 **WindTunnel measures WebMCP against the other ways a browser agent operates a
 website** — same tasks, same real sites, scored on how often each method


### PR DESCRIPTION
Centered header block — name, one-line tagline, nav links, five badges — plus the GitHub Actions workflow that makes the `tests` badge real.

### The five badges
license · benchmark size · built on WebMCP · tests · results (highlighted)

Each is a fact a visitor can't derive from the title. Two candidates were dropped on purpose: a **node** badge (repeats `engines`, where tooling enforces it) and a **methods** count (a finding, not metadata — it duplicates a table further down, and badges that summarize your own results start to read as bragging). No arXiv badge until the paper is posted; no leaderboard badge unless webmcp.com actually publishes these results.

### CI
`npm test` (40 tests) plus `WT_FAKE_LIFECYCLE=1 npm run bench`, on Node 20.11 and 22. The dry run is the valuable half: it exercises task loading, the arm loop, scoring, and report writing on every push with no key, no Docker, and no browser. Node 20.11 in the matrix also proves the floor declared in `engines` is real rather than asserted.

### Verified locally
- every relative README link resolves
- workflow YAML parses; 5 steps, 2-version matrix
- `npm test` 40 passed, 0 failed

The `tests` badge will read "no status" until this merges and the workflow runs on `main` for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)