### PR TITLE
hf/space: short_description within the Hub's 60-character limit

### DIFF
--- a/hf/space/README.md
+++ b/hf/space/README.md
@@ -7,7 +7,7 @@ sdk: static
 app_file: index.html
 pinned: false
 license: apache-2.0
-short_description: Explore the canonical WindTunnel WebMCP browser-agent benchmark.
+short_description: Explore the canonical WindTunnel WebMCP benchmark.
 ---
 
 # WindTunnel Results Explorer


### PR DESCRIPTION
## What

One line in `hf/space/README.md`: the Space card's `short_description` was 64 characters; the Hub enforces ≤ 60 and rejected the board v1.1 Space upload until it was shortened. This is the exact text now live on https://huggingface.co/spaces/nekuda/windtunnel-results-explorer (commit 4fe96e0), so the tracked file matches what is published.

Before: `Explore the canonical WindTunnel WebMCP browser-agent benchmark.` (64)
After: `Explore the canonical WindTunnel WebMCP benchmark.` (50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)